### PR TITLE
Remove the Wayland socket

### DIFF
--- a/org.manaplus.ManaPlus.yaml
+++ b/org.manaplus.ManaPlus.yaml
@@ -10,7 +10,6 @@ finish-args:
   - --share=ipc
   - --share=network
   - --socket=x11
-  - --socket=wayland
   - --device=dri
   - --socket=pulseaudio
   - --persist=.config/mana


### PR DESCRIPTION
The Mana Plus client does not seem to run on Wayland.

Closes #8.